### PR TITLE
Fix missing quote issue

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -645,7 +645,7 @@ Using `cc-mode''s syntactic analysis."
 
 ;; ess-mode binds comma to a function, so we need to advise that function
 ;; to also run our code:
-(eval-after-load 'ess-mode
+(with-eval-after-load 'ess-mode
   (advice-add 'ess-smart-comma :after #'post-self-insert-function))
 
 


### PR DESCRIPTION
Body of eval-after-load is evaluated at macro expansion without quote or wrapped lambda
expression. We can also avoid this issue with 'with-eval-after-load', because
it wraps body with lambda expression.