### PR TITLE
Adds tilde in ess mode

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -726,6 +726,7 @@ Using `cc-mode''s syntactic analysis."
                     (cons "%o%" " %o% ") ; Outer product
                     (cons "%x%" " %x% ") ; Kronecker product
                     (cons "%in%" " %in% ") ; Matching operator
+                    (cons "~" " ~ ") ; "is modeled by"
                     (cons "%>%" " %>% ") ; Pipe (magrittr)
                     (cons "%<>%" " %<>% ") ; Assignment pipe (magrittr)
                     (cons "%$%" " %$% ") ; Exposition pipe (magrittr)


### PR DESCRIPTION
The tilde in R separates left and right sides of a formula. It's read "is modeled by." Not an operator exactly, but definitely a symbol that you want spaces on either side of.