### PR TITLE
Fix comment operators in c-mode

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -610,7 +610,7 @@ Also handles C++ lambda capture by reference."
   "Handle / in #include <a/b>"
   (cond
    ((c-mode-include-line?) "/")
-   ((at-indentation? (alist-get 'start-pos state)) "/") ; Line comment
+   ((at-indentation? (cdr-safe (assq 'start-pos state))) "/") ; Line comment
    (t (prog-mode-/))))
 
 (defun c-mode-// (_)

--- a/features/c-mode-basic-operators.feature
+++ b/features/c-mode-basic-operators.feature
@@ -141,11 +141,26 @@ Feature: C basic operators
   # Comments
   Scenario: // is not spaced internally
     When I type "//"
-    Then I should see "// "
+    Then I should see pattern "^  // $"
+
+  Scenario: // adds space before if not on empty line
+    When I type "expression;//"
+    Then I should see pattern "^  expression; // $"
+
+  Scenario: // does not add space before when at indentation of line
+    When I type "expression;"
+    When I execute newline-and-indent
+    When I type "//"
+    Then I should see pattern "^  expression;$"
+    Then I should see pattern "^  // $"
 
   Scenario: /* is not spaced internally
     When I type "/*"
-    Then I should see "/* "
+    Then I should see pattern "^/\* $"
+
+  Scenario: /* */ is not spaced internally
+    When I type "/**/"
+    Then I should see pattern "^  /\* \*/$"
 
 
   # Type keywords for pointers vs multiplication
@@ -189,27 +204,26 @@ Feature: C basic operators
     When I type "result = foo * *bar"
     Then I should see "result = foo * *bar"
 
-  # # This doesn't actually test what it should, it always passes. Possible
-  # # ecukes bug?
-  # Scenario: // does not lose indentation
-  #   When I insert:
-  #     """
-  #     {
-  #       /
-  #     }
-  #     """
-  #   Then I should see:
-  #     """
-  #     {
-  #       /
-  #     }
-  #     """
-  #   When I go to line "2"
-  #   When I go to end of line
-  #   When I type "/"
-  #   Then I should see:
-  #     """
-  #     {
-  #       //
-  #     }
-  #     """
+  Scenario: // does not lose indentation
+    When I insert:
+      """
+      {
+        /
+      }
+      """
+    Then I should see:
+      """
+      {
+        /
+      }
+      """
+    When I go to line "3"
+    When I go to end of line
+    When I type "/"
+    # The trailing white-space after '//' is intentionally
+    Then I should see:
+      """
+      {
+        // 
+      }
+      """

--- a/features/step-definitions/electric-spacing-steps.el
+++ b/features/step-definitions/electric-spacing-steps.el
@@ -44,3 +44,14 @@
 (When "^I let js2-mode reparse$"
       (lambda ()
         (js2-reparse)))
+
+;; TODO: Figure out why this fails with call-interactively
+;; It works correct with ert but seems to be problematic when used with ecukes
+(When "^I go to end of line$"
+      "Places the cursor at the end of the line."
+      (lambda ()
+        (funcall #'move-end-of-line nil)))
+
+(When "^I execute newline-and-indent$"
+      (lambda ()
+        (newline-and-indent)))


### PR DESCRIPTION
Don't add space before a line comment if it is at the indentation of
the current line (single line comment).

Add a space before a line comment if it is not at the indentation of
the current line.

This requires to keep track of the actual insertion position (ignoring
leading white-space) and passing it to the operator. This might also
be useful for enhancing other c-mode operators by querying cc-mode for
the syntactic symbols at the insertion point.