### PR TITLE
Fix unary prefix and prefix in-/decrement operators

### DIFF
--- a/features/c++-mode.feature
+++ b/features/c++-mode.feature
@@ -4,6 +4,14 @@ Feature: C++ specific operators
     When I turn on c++-mode
     When I turn on electric-operator-mode
 
+  Scenario: Assignment at beginning of line
+    When I type "="
+    And  I press "RET"
+    And  I go to beginning of line
+    And  I type "  ="
+    Then I should see pattern "^=$"
+    And  I should see pattern "^  =$"
+
   Scenario: Automatic type references
     When I type "auto&thing"
     Then I should see "auto &thing"

--- a/features/c++-mode.feature
+++ b/features/c++-mode.feature
@@ -6,11 +6,11 @@ Feature: C++ specific operators
 
   Scenario: Assignment at beginning of line
     When I type "="
-    And  I press "RET"
-    And  I go to beginning of line
-    And  I type "  ="
     Then I should see pattern "^=$"
-    And  I should see pattern "^  =$"
+
+  Scenario: Assignment at beginning of line with indentation
+    When I type "  ="
+    Then I should see pattern "^  =$"
 
   Scenario: Automatic type references
     When I type "auto&thing"

--- a/features/c-mode-basic-operators.feature
+++ b/features/c-mode-basic-operators.feature
@@ -37,6 +37,15 @@ Feature: C basic operators
     When I type "b=++a+c"
     Then I should see "b = ++a + c"
 
+  Scenario: Pre-increment at beginning of line
+    When I turn off minor mode c-toggle-electric-state
+    And  I press "TAB"
+    And  I type "++a;"
+    And  I press "RET"
+    And  I press "TAB"
+    And  I type "++b;"
+    Then I should see pattern "^  \+\+b;$"
+
   Scenario: Post-decrement
     When I type "b=c-a--"
     Then I should see "b = c - a--"
@@ -44,6 +53,15 @@ Feature: C basic operators
   Scenario: Pre-decrement
     When I type "b=--a-c"
     Then I should see "b = --a - c"
+
+  Scenario: Pre-decrement at beginning of line
+    When I turn off minor mode c-toggle-electric-state
+    And  I press "TAB"
+    And  I type "--a;"
+    And  I press "RET"
+    And  I press "TAB"
+    And  I type "--b;"
+    Then I should see pattern "^  --b;$"
 
   Scenario: Post-increment with semi-colon
     When I type "a++;"
@@ -99,6 +117,14 @@ Feature: C basic operators
   Scenario: Assign address of
     When I type "a=&b"
     Then I should see "a = &b"
+
+  Scenario: Address of at beginning of line
+    When I type "&a"
+    And  I press "RET"
+    And  I press "TAB"
+    And  I type "  &b"
+    Then I should see pattern "^&a$"
+    And  I should see pattern "^  &b$"
 
   Scenario: Function call with address of
     Then I type "f(&p,&q)"

--- a/features/c-mode-basic-operators.feature
+++ b/features/c-mode-basic-operators.feature
@@ -120,11 +120,12 @@ Feature: C basic operators
 
   Scenario: Address of at beginning of line
     When I type "&a"
-    And  I press "RET"
-    And  I press "TAB"
-    And  I type "  &b"
     Then I should see pattern "^&a$"
-    And  I should see pattern "^  &b$"
+
+  Scenario: Address of at beginning of line with indentation
+    When I press "TAB"
+    And  I type "&a"
+    Then I should see pattern "^  &a$"
 
   Scenario: Function call with address of
     Then I type "f(&p,&q)"

--- a/features/prog-mode.feature
+++ b/features/prog-mode.feature
@@ -94,7 +94,17 @@ Feature: Generic programming mode spacing
 
   Scenario: Don't space -1
     When I type "-1"
-    Then I should see "-1"
+    And  I press "RET"
+    And  I type "  -1"
+    Then I should see pattern "^-1$"
+    And  I should see pattern "^  -1$"
+
+  Scenario: Don't space +1
+    When I type "+1"
+    And  I press "RET"
+    And  I type "  +1"
+    Then I should see pattern "^\+1$"
+    And  I should see pattern "^  \+1$"
 
   Scenario: a = -1
     When I type "a=-1"
@@ -143,6 +153,54 @@ Feature: Generic programming mode spacing
   Scenario: return
     When I type "return -1"
     Then I should see "return -1"
+
+  Scenario: a = +1
+    When I type "a=+1"
+    Then I should see "a = +1"
+
+  Scenario: a * +1
+    When I type "a*+1"
+    Then I should see "a * +1"
+
+  Scenario: a + +1
+    When I type "a++1"
+    Then I should see "a + +1"
+
+  Scenario: a + +1
+    When I type "a++1"
+    Then I should see "a + +1"
+
+  Scenario: a / +1
+    When I type "a/+1"
+    Then I should see "a / +1"
+
+  Scenario: a ^ +1
+    When I type "a^+1"
+    Then I should see "a ^ +1"
+
+  Scenario: a < +1
+    When I type "a<+1"
+    Then I should see "a < +1"
+
+  Scenario: a > +1
+    When I type "a>+1"
+    Then I should see "a > +1"
+
+  Scenario: a = [+1]
+    When I type "a=[+1]"
+    Then I should see "a = [+1]"
+
+  Scenario: f(+1)
+    When I type "f(+1)"
+    Then I should see "f(+1)"
+
+  Scenario: f(x, +1)
+    When I type "f(x,+1)"
+    Then I should see "f(x, +1)"
+
+  Scenario: return
+    When I type "return +1"
+    Then I should see "return +1"
 
 
   Scenario: Custom rules are applied

--- a/features/step-definitions/electric-spacing-steps.el
+++ b/features/step-definitions/electric-spacing-steps.el
@@ -56,7 +56,6 @@
       (lambda ()
         (newline-and-indent)))
 
-
 (When "^I add a custom rule \"\\([^\"]+\\)\" \"\\([^\"]+\\)\" to \\(.*\\)$"
       (lambda (from to rule-list)
         (add-to-list (intern rule-list) (cons from to))))


### PR DESCRIPTION
When at the beginning of a line, unary prefix and prefix in-/decrement
operators shouldn't be prefixed with a space.

If c-electric-state is on, this will work as the c-electric operations
will fix the indentation. However, if the electric-state is turned off
the additional inserted white-space is not cleaned up and the
indentation was incorrect

Issue #59 