### PR TITLE
Dash in includes

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -425,6 +425,7 @@ Any better ideas would be welcomed."
                     (cons "->" "->")
 
                     (cons "/" #'c-mode-/)
+                    (cons "-" #'c-mode--)
 
                     ;; ternary operator
                     (cons "?" " ? ")
@@ -664,6 +665,12 @@ Also handles C++ lambda capture by reference."
    ((c-mode-include-line?) "/")
    ((handle-c-style-comments-start))
    (t (prog-mode-/))))
+
+(defun c-mode-- ()
+  "Handle - in #include <a-b.h>"
+  (cond
+   ((c-mode-include-line?) "-")
+   (t (prog-mode--))))
 
 (defun c++-probably-lambda-arrow ()
   "Try to guess if we are writing a lambda statement"

--- a/electric-operator.el
+++ b/electric-operator.el
@@ -426,6 +426,7 @@ Any better ideas would be welcomed."
 
                     (cons "/" #'c-mode-/)
                     (cons "-" #'c-mode--)
+                    (cons "\"" #'c-mode-\")
 
                     ;; ternary operator
                     (cons "?" " ? ")
@@ -548,11 +549,20 @@ Using `cc-mode''s syntactic analysis."
        (-map #'car it)
        (-intersection c-function-definition-syntax-list it)))
 
+(defun c-mode-include-line-opening-quote? ()
+  (looking-back-locally "#\s*include\s*"))
+
 (defun c-mode-include-line? ()
   (looking-back-locally "#\s*include.*"))
 
 (defun c-mode-probably-ternary ()
   (looking-back-locally "\\?.+"))
+
+(defun c-mode-\" ()
+  "Handle the opening quote of an include directive"
+  (if (c-mode-include-line-opening-quote?)
+      " \""
+    "\""))
 
 (defun c-mode-: ()
   "Handle the : part of ternary operator"

--- a/features/c-mode-includes.feature
+++ b/features/c-mode-includes.feature
@@ -15,3 +15,7 @@ Feature: #include directives
   Scenario: Include statement with path inside angle brackets
     When I type "#include<old/stdio.h>"
     Then I should see "#include <old/stdio.h>"
+
+  Scenario: Include statement with dash inside angle brackets
+    When I type "#include<some-file.h>"
+    Then I should see "#include <some-file.h>"

--- a/features/c-mode-includes.feature
+++ b/features/c-mode-includes.feature
@@ -4,9 +4,13 @@ Feature: #include directives
     When I turn on c-mode
     When I turn on electric-operator-mode
 
-  Scenario: Include statement
+  Scenario: Include statement with angle brackets
     When I type "#include<stdio.h>"
     Then I should see "#include <stdio.h>"
+
+  Scenario: Include statement with double quotes
+    When I type "#include"stdio.h""
+    Then I should see "#include "stdio.h""
 
   Scenario: Include statement with spaces
     When I type "# include<stdio.h>"
@@ -19,3 +23,7 @@ Feature: #include directives
   Scenario: Include statement with dash inside angle brackets
     When I type "#include<some-file.h>"
     Then I should see "#include <some-file.h>"
+
+  Scenario: Include statement with dash inside quotes
+    When I type "#include"some-file.h""
+    Then I should see "#include "some-file.h""


### PR DESCRIPTION
Support dashes in include directives and include directives with double quotes instead of angle brackets.