### PR TITLE
Don't modify string literals

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -562,7 +562,7 @@ Using `cc-mode''s syntactic analysis."
   "Handle the opening quote of an include directive"
   (cond
    ((c-mode-include-line-opening-quote?) " \"")
-   ((in-docs?) (match-string 0))
+   ((in-docs?) nil)
    (t "\"")))
 
 (defun c-mode-: ()

--- a/electric-operator.el
+++ b/electric-operator.el
@@ -560,9 +560,10 @@ Using `cc-mode''s syntactic analysis."
 
 (defun c-mode-\" ()
   "Handle the opening quote of an include directive"
-  (if (c-mode-include-line-opening-quote?)
-      " \""
-    "\""))
+  (cond
+   ((c-mode-include-line-opening-quote?) " \"")
+   ((in-docs?) (match-string 0))
+   (t "\"")))
 
 (defun c-mode-: ()
   "Handle the : part of ternary operator"

--- a/features/c-mode-basic-operators.feature
+++ b/features/c-mode-basic-operators.feature
@@ -13,6 +13,9 @@ Feature: C basic operators
     When I type "error:"
     Then I should see "error:"
 
+  Scenario: don't modify string literal
+    When I type ""var: " "
+    Then I should see ""var: " "
 
   # Pointer dereference
   Scenario: Space >


### PR DESCRIPTION
Don't remove trailing white-space in a string literal when inserting a
space after the closing double-quote of the string literal.