### PR TITLE
Require subr-x at compile time

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -17,7 +17,7 @@
 
 (require 'cc-mode)
 (require 'thingatpt)
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 
 (require 'dash)
 


### PR DESCRIPTION
subr-x should be required at compile time so that the inline functions
we use from it (`string-join') can be expanded while byte compiling