### PR TITLE
Use space around = in arg annotation with a default value

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -889,7 +889,8 @@ Also handles C++ lambda capture by reference."
   (defun electric-operator-python-mode-kwargs-= ()
     (cond
      ((electric-operator-python-mode-in-lambda-args?) "=")
-     ((eq (electric-operator-enclosing-paren) ?\() "=")
+     ((and (eq (electric-operator-enclosing-paren) ?\()
+           (not (electric-operator-looking-back-locally ":[^,(]*"))) "=")
      (t " = ")))
 
   (defun electric-operator-python-mode-negative-slices ()

--- a/features/python-mode.feature
+++ b/features/python-mode.feature
@@ -153,8 +153,8 @@ Feature: Python mode basics
 
   # Types
   Scenario: Types in function declarations
-    When I type "def foo(x:int)->str:"
-    Then I should see "def foo(x: int) -> str:"
+    When I type "def foo(x:int=timedelta(days=1))->str:"
+    Then I should see "def foo(x: int = timedelta(days=1)) -> str:"
     Then I should not see "str: "
 
   @known-failure


### PR DESCRIPTION
As mentioned here https://www.python.org/dev/peps/pep-0008/#other-recommendations