### PR TITLE
Fixed trailing `*/` sigil without an opening `/*` sigil.

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -570,6 +570,7 @@ Any better ideas would be welcomed."
 
                                       ;; Comments
                                       (cons "/*" " /* ")
+                                      (cons "*/" "*/")
                                       (cons "//" " // ")
 
                                       ;; End of statement inc/decrement, handled separately


### PR DESCRIPTION
WIthout this line, typing `*/` when there is not a corresponding `/*` would produce `* /`. This regularly annoyed me, because I often type the closing delimiter first. This seems to work now, as far as I can tell.