### PR TITLE
Treat treesitter modes just like the corresponding non-treesitter mode

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -485,10 +485,7 @@ Apparently looking-back can be slow without a limit, and calling
 it without a limit is deprecated.
 
 Any better ideas would be welcomed."
-  (let ((two-lines-up (save-excursion
-                        (forward-line -2)
-                        (beginning-of-line)
-                        (point))))
+  (let ((two-lines-up (save-excursion (forward-line -2) (point))))
     (looking-back string two-lines-up greedy)))
 
 

--- a/electric-operator.el
+++ b/electric-operator.el
@@ -220,6 +220,13 @@ Returns a modified copy of the rule list."
 Returns a modified copy of the rule list."
   (electric-operator--add-rule-list initial new-rules))
 
+(defun electric-operator--convert-treesitter-mode (major-mode-symbol)
+  "Convert a treesitter mode name to the equivalent regular mode"
+  (let ((mode-string (symbol-name major-mode-symbol)))
+    (if (string-match-p "-ts-mode" mode-string)
+        (intern (replace-regexp-in-string "-ts-mode" "-mode" mode-string))
+      major-mode-symbol)))
+
 
 ;; All rule manipulation should be done through these functions and not by
 ;; using puthash/gethash directly because it's plausible that the
@@ -227,11 +234,11 @@ Returns a modified copy of the rule list."
 
 (defun electric-operator-get-rules-for-mode (major-mode-symbol)
   "Get the spacing rules for major mode"
-  (electric-operator--trie-get-all (electric-operator-get-rules-trie-for-mode major-mode-symbol)))
+  (electric-operator--trie-get-all (electric-operator-get-rules-trie-for-mode (electric-operator--convert-treesitter-mode major-mode-symbol))))
 
 (defun electric-operator-get-rules-trie-for-mode (major-mode-symbol)
   "Get the spacing rules for major mode"
-  (gethash major-mode-symbol electric-operator--mode-rules-table))
+  (gethash (electric-operator--convert-treesitter-mode major-mode-symbol) electric-operator--mode-rules-table))
 
 (defun electric-operator-add-rules-for-mode (major-mode-symbol &rest new-rules)
   "Replace or add spacing rules for major mode

--- a/features/c-mode-basic-operators.feature
+++ b/features/c-mode-basic-operators.feature
@@ -261,3 +261,11 @@ Feature: C basic operators
   Scenario: Multiplication with pointer deref
     When I type "result = foo * *bar"
     Then I should see "result = foo * *bar"
+
+  # We can't test this yet because emacs doesn't ship with treesitter grammars
+  # and there's no easy way to install them.
+  @known-failure
+  Scenario: Treesitter mode just works
+    When I turn on c-ts-mode
+    When I type "a-b"
+    Then I should see "a - b"

--- a/test/electric-operator-test.el
+++ b/test/electric-operator-test.el
@@ -62,6 +62,28 @@ Aenean in sem ac leo mollis blandit. xyz /=" trie) " /= "))
     (should (equal (electric-operator--trie-get-all trie)
                    (nreverse '(" * " ("1" "2" "3") "6" "xyz" "bar"))))))
 
+(ert-deftest rules-for-treesitter-modes ()
+  (should (equal
+           (electric-operator--convert-treesitter-mode 'c-mode)
+           'c-mode))
+
+  (should (equal
+           (electric-operator--convert-treesitter-mode 'c-ts-mode)
+           'c-mode))
+
+  (should (equal
+           (electric-operator--convert-treesitter-mode 'ts-mode)
+           'ts-mode))
+
+  (should (equal
+           (electric-operator--convert-treesitter-mode 'erts-mode)
+           'erts-mode))
+
+  (should (equal
+           (electric-operator--convert-treesitter-mode 'tsx-ts-mode)
+           'tsx-mode))
+
+  )
 
 ;; Local Variables:
 ;; nameless-current-name: "electric-operator"


### PR DESCRIPTION
Related to #108, but I wasn't able to install treesitter grammars into the tests (yet?) so this doesn't include the part for using treesitter for more accurate rules.