### PR TITLE
Add `^` exponentiation in R

### DIFF
--- a/electric-operator.el
+++ b/electric-operator.el
@@ -1028,6 +1028,7 @@ Also handles C++ lambda capture by reference."
 					                    (cons "%*%" " %*% ") ; Matrix product
 					                    (cons "%o%" " %o% ") ; Outer product
 					                    (cons "%x%" " %x% ") ; Kronecker product
+					                    (cons "^" "^") ; Exponentiation (https://style.tidyverse.org/syntax.html#infix-operators)
 					                    (cons "%in%" " %in% ") ; Matching operator
 					                    (cons "~" " ~ ") ; "is modeled by"
 					                    (cons ":=" " := ")


### PR DESCRIPTION
Since `^` is exponentiation in R, which has a high precedence, it's not generally surrounded with spaces.