### PR TITLE
Silence various messages in tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Key commands
+
+* Compile/lint: make build
+* Test: make test
+* Install deps: make install

--- a/test/ess-mode-test.el
+++ b/test/ess-mode-test.el
@@ -5,6 +5,9 @@
 (require 'test-helper)
 (require 'ess-r-mode)
 
+;; Prevent flymake from warning about R not being installed
+(setq ess-use-flymake nil)
+
 (ert-deftest ess-r-mode-dot-tilde-operator ()
   (th-fixtures #'ess-r-mode
     (th-type "Species~.")

--- a/test/python-mode-test.el
+++ b/test/python-mode-test.el
@@ -4,6 +4,10 @@
 (require 'electric-operator)
 (require 'test-helper)
 
+;; Suppress noisy "Can't guess indent offset" messages from empty test buffers
+(require 'python)
+(setq python-indent-guess-indent-offset-verbose nil)
+
 (ert-deftest python-dont-modify-string-literal ()
   (th-fixtures #'python-mode
     (th-type "'var+foo-1'")


### PR DESCRIPTION
Set python-indent-guess-indent-offset-verbose to nil so python-mode doesn't emit noisy messages when it can't guess the indent offset from empty test buffers.